### PR TITLE
Rotation Angle Fix

### DIFF
--- a/src/main/com/github/draylar/LineConverter.java
+++ b/src/main/com/github/draylar/LineConverter.java
@@ -74,17 +74,17 @@ public class LineConverter
 
         if(string.contains("rotateAngleX = x;"))
         {
-            return "        modelRenderer.rotationPointX = x;";
+            return "        modelRenderer.pitch = x;";
         }
 
         if(string.contains("rotateAngleY = y;"))
         {
-            return "        modelRenderer.rotationPointY = y;";
+            return "        modelRenderer.yaw = y;";
         }
 
         if(string.contains("rotateAngleZ = z;"))
         {
-            return "        modelRenderer.rotationPointZ = z;";
+            return "        modelRenderer.roll = z;";
         }
 
         return string;


### PR DESCRIPTION
I'm unsure whether fabric mappings changed these variable names at some point or if the tool has always been broken but this will fix the issue either way.

In the method _setRotationAngle(Cuboid modelRenderer, float x, float y, float z)_ previous to this pull request the tool had this method change the cuboid's rotation points and not angles.

Forge 1.12 Code:
```
        public void setRotationAngle(ModelRenderer modelRenderer, float x, float y, float z) {
	        modelRenderer.rotateAngleX = x;
	        modelRenderer.rotateAngleY = y;
	        modelRenderer.rotateAngleZ = z;
        }
```

V1.0.1 of this tool:
```
        public void setRotationAngle(Cuboid modelRenderer, float x, float y, float z) {
                modelRenderer.rotationPointX = x;
                modelRenderer.rotationPointY = y;
                modelRenderer.rotationPointZ = z;
        }
```

My fix:
```
        public void setRotationAngle(Cuboid modelRenderer, float x, float y, float z) {
                modelRenderer.pitch = x;
                modelRenderer.yaw = y;
                modelRenderer.roll = z;
        }
```

This fix turned this:
![image](https://user-images.githubusercontent.com/29845000/69643904-ed5da280-1031-11ea-91d3-797833d5e21d.png)

into this:
![image](https://user-images.githubusercontent.com/29845000/69643951-fc445500-1031-11ea-84c0-83b91d51ba3d.png)
